### PR TITLE
Fixed broken process test coverage tool

### DIFF
--- a/snippets/process-test-coverage/README.md
+++ b/snippets/process-test-coverage/README.md
@@ -1,11 +1,20 @@
 # Introduction
+This tool supports in analyzing and visualizing the process test coverage of a BPMN process.
+
+The tool creates test coverages for:
+* Test cases: The process coverage is visualized by marking those tasks and events with a green color which have be traversed by the test case.
+* Test suites: The process coverage is visualized by marking those tasks and events with a green color which have be traversed by any of the test suite's test cases.
 
 # Environment Restrictions
+Current browsers generally restrict access when sharing resources across domains due to security reasons. The BPMN resource can only be loaded if cross-origin resource sharing is enabled.
+
+Cross-origin resource sharing may generally enabled (and security disabled!) by:
+* Chrome: Start Chrome with the parameter "--allow-file-access-from-files"
+* Firefox: about:config -> security.fileuri.strict_origin_policy -> false
 
 # Remarks to run this application
-There is no web interface to access the application. To get started refer to the
-Arquillian test case, which by default connects to a camunda BPM Platform running
-locally on JBoss AS 7.
+1. mvn clean test
+2. Open html files which are created in the directory target/process-test-coverage/
 
 # Known Issues
 

--- a/snippets/process-test-coverage/src/main/resources/camunda-bpmn.js-template.html
+++ b/snippets/process-test-coverage/src/main/resources/camunda-bpmn.js-template.html
@@ -31,7 +31,7 @@
       baseUrl: "",
       paths: {
         'jquery' : 'http://code.jquery.com/jquery-1.11.0.min',
-        'bpmn/Bpmn' : 'https://raw.githubusercontent.com/camunda/camunda-bpmn.js/master/build/bpmn.min.js',
+        'bpmn/Bpmn' : 'https://rawgit.com/camunda/camunda-bpmn.js/master/build/bpmn.min',
       },
       packages: [
         { name: "dojo", location: "http://yandex.st/dojo/1.9.1/dojo/dojo" },


### PR DESCRIPTION
- removed ".js" from bpmn URL because it is added automatically (prevents FileNotFound).
- replaced raw.githubusercontent.com with rawgit.com because GitHub enforced strict MIME type checking which prevents loading in Chrome browser (see http://stackoverflow.com/questions/17341122/link-and-execute-external-javascript-file-hosted-on-github)
- updated README to document browser security restrictions

Tested with Chromium 37 and Firefox 35.