### PR TITLE
Fix @AfterClass to @After

### DIFF
--- a/snippets/process-test-coverage/README.md
+++ b/snippets/process-test-coverage/README.md
@@ -25,9 +25,9 @@ Add this Maven Dependency to your project:
 
 Have a look at the [ProcessTestCoverageTest](src/test/java/org/camunda/bpm/consulting/process_test_coverage/ProcessTestCoverageTest.java):
 
-- In a tearDown() or @AfterClass method for the Test Class coverage
+- In a tearDown() or @After method for the Test Class coverage
 ```java
-  @AfterClass
+  @After
   public void calculateCoverage() throws Exception {
     // calculate coverage for all tests
     ProcessTestCoverage.calculate(processEngineRule.getProcessEngine());


### PR DESCRIPTION
AfterClass won't work since it requires a static method. Making the method static does not allow access to processEngine anymore. Workarounds like camunda-bpm-asserts "processEngine()" static accessor are instable since you cannot know if that engine has already been shut down when the @AfterClass is executed. So how I see it, there is no other option than to use this after every single test.