### PR TITLE
chore(skill-based-routing): make javascript java 6 and 7 compatible

### DIFF
--- a/showcases/de/skill-based-routing/src/main/resources/mitarbeiterBestimmen.bpmn
+++ b/showcases/de/skill-based-routing/src/main/resources/mitarbeiterBestimmen.bpmn
@@ -22,8 +22,8 @@
 
 var selectedEmployee;
 
-for (var i = 0; i < employees.length; i++) {
-    var employee = employees[i];
+for (var i = 0; i < employees.size(); i++) {
+    var employee = employees.get(i);
     if (!selectedEmployee || employee.score > selectedEmployee.score) {
            selectedEmployee = employee;
     }

--- a/showcases/en/skill-based-routing/src/main/resources/determineEmployee.bpmn
+++ b/showcases/en/skill-based-routing/src/main/resources/determineEmployee.bpmn
@@ -33,8 +33,8 @@
 
 var selectedEmployee;
 
-for (var i = 0; i < employees.length; i++) {
-    var employee = employees[i];
+for (var i = 0; i < employees.size(); i++) {
+    var employee = employees.get(i);
     if (!selectedEmployee || employee.score > selectedEmployee.score) {
            selectedEmployee = employee;
     }


### PR DESCRIPTION
The skill base routing example currently only works with Java 8 resp. the
nashorn javascript engine. If the javascript script uses the java methods
size() and get() it is also working on java 6 and 7.